### PR TITLE
bugfixes

### DIFF
--- a/connectors/data.json
+++ b/connectors/data.json
@@ -5,7 +5,6 @@
         "category": "Directory Service",
         "description": "Active Directory (AD) is a directory service that Microsoft developed for Windows domain networks. You can directly query AD to retrieve information about users, groups, and computers, in an organization, by using the Lightweight Directory Access Protocol (LDAP) to directly query the AD.",
         "publisher": null,
-        "version": "2.2.0",
         "operation_roles": {
             "add_object": [],
             "get_all_object_details": [],
@@ -24,9 +23,28 @@
         },
         "configurations": [],
         "dataImports": [],
-        "rpm_name": "cyops-connector-activedirectory-2.2.0",
-        "install_mode": "rpm",
-        "installer_path": "cyops-connector-activedirectory-2.2.0"
+        "install_mode": "rpm"
+    },
+    {
+        "name": "symantec-cloudsoc",
+        "label": "Symantec CloudSOC",
+        "category": "Cloud Security Log",
+        "description": "The Symantec CloudSOC platform enables companies to confidently leverage cloud applications and services while staying safe, secure, and compliant",
+        "publisher": null,
+        "operation_roles": {
+            "get_logs": [],
+            "get_audit_data_source": [],
+            "get_audit_service": [],
+            "get_audit_user": [],
+            "get_audit_username": [],
+            "get_audit_summary": [],
+            "get_content_iqprofile": [],
+            "get_protect_policies": [],
+            "modify_user": []
+        },
+        "configurations": [],
+        "dataImports": [],
+        "install_mode": "rpm"
     },
     {
         "name": "symantec-dlp",
@@ -34,7 +52,6 @@
         "category": "Network Visibility",
         "description": "Symantec DLP provide actions like get incident attachments, get incident details, get incident status, update incident etc.",
         "publisher": null,
-        "version": "2.2.0",
         "operation_roles": {
             "get_incident_status": [],
             "get_incident_attachment": [],
@@ -49,8 +66,6 @@
         },
         "configurations": [],
         "dataImports": [],
-        "rpm_name": "cyops-connector-symantec-dlp-2.2.0",
-        "install_mode": "rpm",
-        "installer_path": "cyops-connector-symantec-dlp-2.2.0"
+        "install_mode": "rpm"
     }
 ]

--- a/info.json
+++ b/info.json
@@ -21,17 +21,15 @@
         }
     ],
     "prerequisite": "",
-    "certified": "true",
+    "certified": "false",
     "publisher": "Fortinet",
-    "description": "Solution pack investigates data leakage alert ingested from Symantec CloudSOC",
+    "description": "Solution pack investigates data leakage alert ingested from Symantec CloudSOC. Few important integrations used in the solution pack are Microsoft Active Directory, Symantec CloudSOC and Symantec DLP.",
     "help": "https:\/\/github.com\/fortinet-fortisoar\/solution-pack-data-leakage-threat-response\/blob\/develop\/README.md",
     "category": [],
-    "supportInfo": "support@fortinet.com",
+    "supportInfo": "",
     "iconLarge": null,
     "fsrMinCompatibility": "7.2.0",
-    "date": "2022-02-19T19:21:24+00:00",
-    "exported_from": "tenant.fortinet.com",
-    "exported_by": "CS Admin",
+    "date": "2022-04-08T13:23:18+00:00",
     "contents": {
         "picklistNames": [
             {
@@ -49,16 +47,24 @@
             }
         },
         "viewTemplates": {
-            "employeewatchlist": [
-                "list",
-                "detail",
-                "form"
-            ],
-            "sensitivefile": [
-                "list",
-                "detail",
-                "form"
-            ]
+            "employeewatchlist": {
+                "name": "Employee Watchlist",
+                "apiName": "employeewatchlist",
+                "views": [
+                    "list",
+                    "detail",
+                    "form"
+                ]
+            },
+            "sensitivefile": {
+                "name": "Sensitive Files",
+                "apiName": "sensitivefile",
+                "views": [
+                    "list",
+                    "detail",
+                    "form"
+                ]
+            }
         },
         "views": {
             "navigation": [
@@ -87,6 +93,10 @@
             {
                 "name": "Active Directory",
                 "apiName": "activedirectory"
+            },
+            {
+                "name": "Symantec CloudSOC",
+                "apiName": "symantec-cloudsoc"
             },
             {
                 "name": "Symantec DLP",


### PR DESCRIPTION
Mantis #0781959
- Removed `exported_from` and `exported_by` keys
- Marked SP as `uncertified`
- Added connector names in the solution pack description
- Updated view template entries to the latest format

Mantis #0798963
- Added Symantec CloudSOC connector into the SP